### PR TITLE
Remove extra character from InstallerUtil so dev branch works

### DIFF
--- a/src/PatternLab/InstallerUtil.php
+++ b/src/PatternLab/InstallerUtil.php
@@ -350,7 +350,7 @@ class InstallerUtil {
 				foreach ($finder as $file) {
 					
 					$ext      = $file->getExtension();
-					$pathName = $file->getPathname());
+					$pathName = $file->getPathname();
 					
 					if ($ext == "css") {
 						$componentTypes["stylesheets"][] = str_replace(DIRECTORY_SEPARATOR,"/",str_replace($sourceBase.$source,$destination,$pathName));


### PR DESCRIPTION
Removes extra closing parentheses so dev branch actually works and can be composer installed. 

Addresses existing 8 month old PR (https://github.com/pattern-lab/patternlab-php-core/pull/87) so we have a clean dev branch to work off of.