### PR TITLE
Updating global data to use `yml` or `yaml`

### DIFF
--- a/src/PatternLab/Data.php
+++ b/src/PatternLab/Data.php
@@ -125,7 +125,7 @@ class Data {
 			$pathName      = $file->getPathname();
 			$pathNameClean = str_replace($sourceDir."/","",$pathName);
 
-			if (!$hidden && (($ext == "json") || ($ext == "yaml"))) {
+			if (!$hidden && (($ext == "json") || ($ext == "yaml") || ($ext == "yml"))) {
 
 				if ($isListItems === false) {
 
@@ -137,7 +137,7 @@ class Data {
 							JSON::lastErrorMsg($pathNameClean,$jsonErrorMessage,$data);
 						}
 
-					} else if ($ext == "yaml") {
+					} else if (($ext == "yaml") || ($ext == "yml")) {
 
 						$file = file_get_contents($pathName);
 


### PR DESCRIPTION
Creating this fix from my upstream PR: https://github.com/pattern-lab/patternlab-php-core/pull/98 

Would resolve https://github.com/pattern-lab/patternlab-php-core/issues/93 - global data files have to `json` or `yaml` - confusing as the pattern specific data files can be `json`, `yaml`, or `yml`.
