### PR TITLE
Fix for Broken Lineage Functionality in PL When Using Twig templates w/ Path Namespaces (ie. Drupal 8-friendly Paths)

### DIFF
--- a/src/PatternLab/PatternData/Helpers/LineageHelper.php
+++ b/src/PatternLab/PatternData/Helpers/LineageHelper.php
@@ -53,6 +53,51 @@ class LineageHelper extends \PatternLab\PatternData\Helper {
 					
 					foreach ($foundLineages as $lineage) {
 						
+					/**
+						* Fix for Pattern Lab Lineages when using Twig Namespaces. 
+						* Converts the full file path to PL-friendly shorthand so 
+						* they are internally registered.
+						*
+						* 1.  Only handle instances where we aren't or can't use the 
+						*     shorthand PL path reference in templates, specifically 
+						*     in Twig / D8 when we need to use Twig namespaces in 
+						*     our template paths.
+						* 2.  Strip off the @ sign at the beginning of our $lineage string.
+						* 3.  Break apart the full lineage path based on any slashes that
+						*     may exist.
+						* 4.  Store the length of our broken up path for reference below
+						* 5.  Store the first part of the string up to the first slash "/"
+						* 6.  Now grab the last part of the pattern key, based on the length
+						*     of the path we previously exploded.
+						* 7.  Remove any "_" from pattern Name.
+						* 8.  Remove any potential prefixed numbers or number + dash 
+						*     combos on our Pattern Name.
+						* 9.  Strip off the pattern path extension (.twig, 
+						*     .mustache, etc) if it exists.
+						* 10. If the pattern name parsed had an extension, 
+						*     re-assign our Pattern Name to that.
+						* 11. Finally, re-assign $lineage to the default PL pattern key.
+						*/
+
+						if ($lineage[0] == '@') {                    /* [1] */
+							$lineage = ltrim($lineage, '@');           /* [2] */
+							$lineageParts = explode('/', $lineage);    /* [3] */
+							$length = count($lineageParts);            /* [4] */
+							$patternType = $lineageParts[0];           /* [5] */
+
+							$patternName = $lineageParts[$length - 1]; /* [6] */
+							$patternName = ltrim($patternName, '_');   /* [7] */
+							$patternName = preg_replace('/^[0-9\-]+/', '', 
+							$patternName); /* [8] */
+
+							$patternNameStripped = explode('.' . $patternExtension, $patternName); /* [9] */
+
+							if (count($patternNameStripped) > 1) { /* [10] */
+								$patternName = $patternNameStripped[0];
+							}
+							$lineage = $patternType . "-" . $patternName;	/* [11] */
+						}
+
 						if (PatternData::getOption($lineage)) {
 							
 							$patternLineages[] = array("lineagePattern" => $lineage,


### PR DESCRIPTION
Addresses this [open issue ](https://github.com/drupal-pattern-lab/patternlab-php-core/issues/3) and corresponds with the 2nd half of work [mentioned here](https://github.com/drupal-pattern-lab/patternengine-php-twig/pull/1).

Note: the regex updates added to the Pattern Lab Twig Engine fork (PR from above) are required in order for this update to work as expected. 

Lemme know if there's anything I can help clarify on this!

Author's note(s):
- 1. Given that I'm really not a PHP / Drupal dev, I'm commenting the crap out of what I came up with  to hopefully make a bit more sense. I'm sure there's a better way of handling with but at least this rough around the edges approach seems to work...
- 2. Can we please move over to using spaces instead of tabs at some point? *grumble grumble*
- 3. Kinda related to number 2, could we also fix these forked repos to use the standard git flow "develop" branch convention? Any particular reason why we should stick to using "dev"?