### PR TITLE
Replace possible dots in pattern names with dashes

### DIFF
--- a/src/PatternLab/PatternData/Rule.php
+++ b/src/PatternLab/PatternData/Rule.php
@@ -104,6 +104,9 @@ class Rule {
 	protected function getPatternName($pattern, $clean = true) {
 		$patternBits = explode("-",$pattern,2);
 		$patternName = (((int)$patternBits[0] != 0) || ($patternBits[0] == '00')) ? $patternBits[1] : $pattern;
+    // replace possible dots with dashes. pattern names cannot contain dots
+    // since they are used as id/class names in the styleguidekit.
+    $patternName = str_replace('.', '-', $patternName);
 		return ($clean) ? (str_replace("-"," ",$patternName)) : $patternName;
 	}
 	


### PR DESCRIPTION
Pattern names are used as id/class names in the PL frontend. If pattern names contain dots some PL frontend functionality breaks.

This is an especially important change when using the `.html.twig` naming convention recommended by the Symfony project and used by Drupal. Twig files are not restricted to HTML after all! :)