### PR TITLE
Allow Pattern Lab to follow pattern symlinks when registering patterns

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -116,14 +116,13 @@ class PatternData {
 		if (!is_dir(Config::getOption("patternSourceDir"))) {
 			Console::writeError("having patterns is important. please make sure you've installed a starterkit and/or that ".Console::getHumanReadablePath(Config::getOption("patternSourceDir"))." exists...");
 		}
-		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator(Config::getOption("patternSourceDir")), \RecursiveIteratorIterator::SELF_FIRST);
-		$patternObjects->setFlags(\FilesystemIterator::SKIP_DOTS);
+
+		$patternSourceDir = Config::getOption("patternSourceDir");
+		$patternObjects = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($patternSourceDir, \RecursiveDirectoryIterator::FOLLOW_SYMLINKS | \FilesystemIterator::SKIP_DOTS), \RecursiveIteratorIterator::SELF_FIRST);
 
 		// sort the returned objects
 		$patternObjects = iterator_to_array($patternObjects);
 		ksort($patternObjects);
-
-		$patternSourceDir = Config::getOption("patternSourceDir");
 
 		foreach ($patternObjects as $name => $object) {
 


### PR DESCRIPTION
Enabling the ability for Pattern Lab to follow any symlinks that may exist when scanning the pattern source directory for patterns; adds the RecursiveIteratorIterator flag to follow symbolic links while still continuing to skip dots (. and ..).

This opens the door for some creative workarounds to the rigid way Pattern Lab expects pattern templates to be organized at the file system level + how the physical path to a pattern determines how it's organized in Pattern Lab... https://github.com/pattern-lab/patternlab-php-core/issues/28