### PR TITLE
Update Pattern Lab PHP Core Minimum PHP Version to 7.0+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     }
   },
   "require": {
-    "php": ">=5.4",
+    "php": ">=7.0",
     "alchemy/zippy": "^0.3",
     "kevinlebrun/colors.php": "^1.0",
     "michelf/php-markdown": "^1.6",


### PR DESCRIPTION
Updating the minimum PHP dependency in Pattern Lab PHP Core to PHP 7.0 to open the door for more concise ways to write out common PHP logic (ex. the Null coalescing operator - https://stackoverflow.com/a/36796941) in addition to the performance gains PHP 7 introduced.

Given that PHP 7.0 first came out nearly 2 years ago (December 3rd, 2015) I think it's about time we took the plunge...

Perhaps we could use this as a base for a major Pattern Lab PHP Core v3.0.0 release?