### PR TITLE
Add Ability to Disable Default Pattern Data Rules + Add Extra Pattern Data Rules

### DIFF
--- a/src/PatternLab/PatternData.php
+++ b/src/PatternLab/PatternData.php
@@ -386,16 +386,50 @@ class PatternData {
 
 	}
 
-	/**
-	* Load all of the rules related to Pattern Data
+
+/**
+	* Load all of the rules related to Pattern Data, plus any extra add-ons
 	*/
 	public static function loadRules($options) {
+		// First handle default PL rules, minus any being disabled
 		foreach (glob(__DIR__."/PatternData/Rules/*.php") as $filename) {
 			$ruleName = str_replace(".php","",str_replace(__DIR__."/PatternData/Rules/","",$filename));
-			if ($ruleName[0] != "_") {
+
+			$disabledRules = array();
+			if (Config::getOption("disabledPatternRules")) {
+				$disabledRules = Config::getOption("disabledPatternRules");
+			}
+
+			// Load all rules that aren't on the disabledPatternRules list
+			if (($ruleName[0] != "_") && (!in_array($ruleName, $disabledRules))) {
 				$ruleClass = "\PatternLab\PatternData\Rules\\".$ruleName;
 				$rule      = new $ruleClass($options);
 				self::setRule($ruleName, $rule);
+			}
+		}
+
+		// Then handle any extra rules to add on top of the default PL rules
+		$extraPatternRulesDir = Config::getOption("sourceDir") . '/_extensions/rules'; // Default extra rules location to check
+		if (Config::getOption("extraPatternRulesDir")) {
+			$extraPatternRulesDir = Config::getOption("extraPatternRulesDir");
+		}
+
+		if (is_dir($extraPatternRulesDir)){
+			foreach (glob($extraPatternRulesDir . "/*.php") as $filename) {
+				$ruleName = str_replace(".php","",str_replace($extraPatternRulesDir . "/","",$filename));
+
+				$extraRules = array();
+				if (Config::getOption("extraPatternRules")) {
+					$extraRules = Config::getOption("extraPatternRules");
+				}
+
+				// Only load extra rules that are on the extraPatternRules list
+				if (($ruleName[0] != "_") && (in_array($ruleName, $extraRules))) {
+					require_once($filename); // Pull in extra rule so we can use it
+					$ruleClass = "\PatternLab\PatternData\Rules\\".$ruleName;
+					$rule      = new $ruleClass($options);
+					self::setRule($ruleName, $rule);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Allows for for any of the default set of Pattern Lab data rules to be optionally disabled in addition to allowing for extra rules to be added as well. While not that big of a change in of itself (besides checking a couple optional config options) this opens the door wide open for the customization and continued evolution of Pattern Lab well beyond what is currently possible.

*cough [Installable Components](https://github.com/pattern-lab/patternlab-php-core/issues/28) cough*

Should address the two main use cases described in #11.

## To Disable A Default Pattern Lab Rule 
For example, to disable the default Markdown documentation rule, add the following to your config.yml file:
```
disabledPatternRules:
    - DocumentationRule
```

## To Add A New Custom Rule
To add a new extra rule (say, to locally add in a super-powered markdown data rule that allows Twig templates to get embedded and compiled in .md files) add the following to your `config.yml` config + create a new `_extensions/rules` folder in your PL source folder to house your new Rule files.

```
extraPatternRules:
    - DocumentationRule
```
With a new test rule file (`DocumentationRule.php`) added to `source/_extensions/rules/DocumentationRule.php`

## Customize Pattern Rule Folder Location
There's also an optional config option to specify the location of your rules folder:
```
extraPatternRulesDir: "source_my-extensions/rules"
```


CC @evanmwillhite @aleksip @legostud

Side note: @christophersmith262 sorry, I totally didn't realize you had already created a feature branch for this a while back (allowing for default PL rules to be disabled) until I was tried to push my feature branch for this. 

Could you take a peek at what I came up with to see if there's a way to incorporate your single array / loop approach idea with this while still allowing for rules to either be opted out of and/or opted in?