### PR TITLE
Adding Ability for Markdown Files to Specify Which Pattern It Should Be Associated With (ex. README.md)

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -31,9 +31,20 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$this->ignoreProp = "";
 		
 	}
-	
+
 	public function run($depth, $ext, $path, $pathName, $name) {
-		
+		// default vars
+		$patternSourceDir = Config::getOption("patternSourceDir");
+
+		// parse data
+		$text = file_get_contents($patternSourceDir.DIRECTORY_SEPARATOR.$pathName);
+		list($yaml,$markdown) = Documentation::parse($text);
+
+		if (isset($yaml["patternType"])) {
+			$name = $yaml["patternType"];
+			unset($yaml["patternType"]);
+		}
+
 		// load default vars
 		$patternType        = PatternData::getPatternType();
 		$patternTypeDash    = PatternData::getPatternTypeDash();
@@ -43,14 +54,7 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$doc        = str_replace(".".$this->extProp,"",$name);              // 00-colors
 		$docDash    = $this->getPatternName(str_replace("_","",$doc),false); // colors
 		$docPartial = $patternTypeDash."-".$docDash;
-		
-		// default vars
-		$patternSourceDir = Config::getOption("patternSourceDir");
-		
-		// parse data
-		$text = file_get_contents($patternSourceDir.DIRECTORY_SEPARATOR.$pathName);
-		list($yaml,$markdown) = Documentation::parse($text);
-		
+
 		// grab the title and unset it from the yaml so it doesn't get duped in the meta
 		if (isset($yaml["title"])) {
 			$title = $yaml["title"];
@@ -68,9 +72,8 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 					break;
 				}
 			}
-			
 		}
-		
+
 		$category         = ($patternSubtypeDoc) ? "patternSubtype" : "pattern";
 		$patternStoreKey  = ($patternSubtypeDoc) ? $docPartial."-plsubtype" : $docPartial;
 		


### PR DESCRIPTION
For example, if I had a colors.twig file in my code with a README.md file living right next to it (living in a colors folder), currently this file is completely ignored by Pattern Lab.

This update adds the ability to specify a `patternType` option in the markdown file's front matter to tell Pattern Lab which pattern it should be associated with (or more specifically, which patternType it should be associated with).

```
---
title: Color Palette
patternType: colors
---

Our primary palette consists of our primary brand color...
```

Besides offering more flexible in how files are named, this also helps make Pattern Lab much friendlier to monorepo projects where each pattern might be individually versioned, documented, and published to NPM and/or Github where README.md filenames provide a better user experience if browsing a pattern's source files.

CC @aleksip @EvanLovely @evanmwillhite 