### PR TITLE
Compile Templates Embedded in Markdown Files

### DIFF
--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -90,8 +90,16 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$patternLoader           = new $patternLoaderClass($options);
 
 
-		// Setup the default pattern data.
-		$data = Data::getPatternSpecificData($patternStoreKey);
+		// Combine local + global pattern data.
+		$data = array();
+		$globalData = Data::getPatternSpecificData($docPartial);
+		$localData = PatternData::getOption($docPartial)["data"];
+
+		if ($localData){
+			$data = array_replace_recursive($localData, $globalData);
+		} else {
+			$data = $globalData;
+		}
 
 		// Render the markdown content as a pattern, piping in the pattern-specific data from above.
 		$text = $patternLoader->render(array(

--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -16,6 +16,9 @@ use \PatternLab\Config;
 use \PatternLab\PatternData;
 use \PatternLab\Parsers\Documentation;
 use \PatternLab\Timer;
+use \PatternLab\Data;
+use \PatternLab\PatternData\Exporters\PatternPathSrcExporter;
+use \PatternLab\PatternEngine;
 
 class DocumentationRule extends \PatternLab\PatternData\Rule {
 	
@@ -49,8 +52,7 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		
 		// parse data
 		$text = file_get_contents($patternSourceDir.DIRECTORY_SEPARATOR.$pathName);
-		list($yaml,$markdown) = Documentation::parse($text);
-		
+
 		// grab the title and unset it from the yaml so it doesn't get duped in the meta
 		if (isset($yaml["title"])) {
 			$title = $yaml["title"];
@@ -73,7 +75,34 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		
 		$category         = ($patternSubtypeDoc) ? "patternSubtype" : "pattern";
 		$patternStoreKey  = ($patternSubtypeDoc) ? $docPartial."-plsubtype" : $docPartial;
-		
+
+		/**
+		* Setup the Pattern Loader so we can pre-render template markup used
+		* in our markdown files, prior to any markup getting parsed.
+		* Taken from Builder.php
+		*/
+		$ppdExporter             = new PatternPathSrcExporter();
+		$patternPathSrc          = $ppdExporter->run();
+		$options                 = array();
+		$options["patternPaths"] = $patternPathSrc;
+		$patternEngineBasePath   = PatternEngine::getInstance()->getBasePath();
+		$patternLoaderClass      = $patternEngineBasePath . "\Loaders\PatternLoader";
+		$patternLoader           = new $patternLoaderClass($options);
+
+
+		// Setup the default pattern data.
+		$data = Data::getPatternSpecificData($patternStoreKey);
+
+		// Render the markdown content as a pattern, piping in the pattern-specific data from above.
+		$text = $patternLoader->render(array(
+			"pattern" => $text,
+			"data" => $data
+		));
+
+		// Finally parse the resulting content as normal markup; continue as usual.
+		list($yaml,$markdown) = Documentation::parse($text);
+
+
 		$patternStoreData = array("category"   => $category,
 								  "desc"       => trim($markdown),
 								  "descExists" => true,

--- a/src/PatternLab/PatternData/Rules/DocumentationRule.php
+++ b/src/PatternLab/PatternData/Rules/DocumentationRule.php
@@ -96,7 +96,7 @@ class DocumentationRule extends \PatternLab\PatternData\Rule {
 		$localData = PatternData::getOption($docPartial)["data"];
 
 		if ($localData){
-			$data = array_replace_recursive($localData, $globalData);
+			$data = array_replace_recursive($globalData, $localData);
 		} else {
 			$data = $globalData;
 		}


### PR DESCRIPTION
You know the thing that really sucks about documenting your growing design system? When your docs you spent so much time putting together get out of sync with your source of truth. Again.

Wouldn't it be amazing if we could just use the same data and the same templates being put INTO the system to DOCUMENT the system itself? What's that? I already [put a PR in for that](https://github.com/pattern-lab/patternlab-php-core/pull/104) on the original Pattern Lab PHP Core repo... **10 months ago?** Oh snap!

In all seriousness, this is a major feature we've been seriously lacking in Pattern Lab's markdown docs approach for forever. This PR should fix that by letting you use the same templates and same data as you would with any other pattern in Pattern Lab, but in your markdown files.

Testing this out locally seems to be working as expected (global data trickling through, local data overriding global data if it exists, and pattern includes w/ namespaces) -- all seem to be working perfectly at first glance!

Before:
![image](https://user-images.githubusercontent.com/1617209/29999976-5fa01052-9029-11e7-82a9-fd3405bef6af.png)

After:
![image](https://user-images.githubusercontent.com/1617209/29999977-70762510-9029-11e7-93d6-facf55b4b52f.png)

Practical Usage Example:
![image](https://user-images.githubusercontent.com/1617209/29999982-8b7f779e-9029-11e7-8c25-2e91eb329d6c.png)
![image](https://user-images.githubusercontent.com/1617209/29999983-96a5c574-9029-11e7-964a-bfb3047a3a98.png)

CC @EvanLovely @evanmwillhite @jesconstantine @aleksip @bradfrost