### PR TITLE
Reference The Correct Template In Psuedo Patterns If JSON File and Template Live in Different Folders

### DIFF
--- a/src/PatternLab/Builder.php
+++ b/src/PatternLab/Builder.php
@@ -261,6 +261,20 @@ class Builder {
 				// modify the pattern mark-up
 				$markup        = $patternStoreData["code"];
 				$markupFull    = $patternStoreData["header"].$markup.$patternStoreData["footer"];
+
+
+				/** If the base template for a JSON / Yaml file (or psuedo pattern variation) lives in a different folder, 
+					* use the `original` pattern's template instead. 
+					* Fixes https://github.com/drupal-pattern-lab/patternlab-php-core/issues/22
+					*/
+				if (!file_exists($patternSourceDir."/".$pathName.".".$patternExtension)){
+					$originalPatternPathName = PatternData::getOption($patternStoreData["original"])["pathName"];
+					if (file_exists($patternSourceDir."/".$originalPatternPathName.".".$patternExtension)){
+						$pathName = $originalPatternPathName;
+					}
+				}
+
+
 				$markupEngine  = file_get_contents($patternSourceDir."/".$pathName.".".$patternExtension);
 
 				// if the pattern directory doesn't exist create it


### PR DESCRIPTION
Fixes this long existing (and rather annoying) issue with psuedo patterns throwing errors left and right if the template a psueo-pattern is based on ends up living in a separate folder.

Addresses https://github.com/drupal-pattern-lab/patternlab-php-core/issues/22

<img width="289" alt="builder_php_ _bolt" src="https://user-images.githubusercontent.com/1617209/31097279-c1d9edd6-a78c-11e7-9e8a-aef854d363b7.png">
